### PR TITLE
Refactor: use common RestClient to make rest calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <repository.name>hygieia-artifact-artifactory-collector</repository.name>
     <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
     <bc.version>3.0.1</bc.version>
-    <com.capitalone.dashboard.core.version>3.1.5</com.capitalone.dashboard.core.version>
+    <com.capitalone.dashboard.core.version>3.1.9</com.capitalone.dashboard.core.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang.version>3.8.1</commons.lang.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>

--- a/src/test/java/com/capitalone/dashboard/collector/DefaultArtifactoryClientTest.java
+++ b/src/test/java/com/capitalone/dashboard/collector/DefaultArtifactoryClientTest.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.collector;
 
+import com.capitalone.dashboard.client.RestClient;
 import com.capitalone.dashboard.model.ArtifactoryRepo;
 import com.capitalone.dashboard.model.BaseArtifact;
 import com.capitalone.dashboard.model.BinaryArtifact;
@@ -58,7 +59,7 @@ public class DefaultArtifactoryClientTest {
 		r.setPatterns(Arrays.asList(ArtifactUtilTest.IVY_PATTERN1, ArtifactUtilTest.IVY_ARTIFACT_PATTERN1, ArtifactUtilTest.MAVEN_PATTERN1,ArtifactUtilTest.ARTIFACT_PATTERN));
 		serverSetting.setRepoAndPatterns(Collections.singletonList(r));
         settings.setServers(Collections.singletonList(serverSetting));
-        defaultArtifactoryClient = new DefaultArtifactoryClient(settings, restOperationsSupplier,binaryArtifactRepository);
+        defaultArtifactoryClient = new DefaultArtifactoryClient(settings, new RestClient(restOperationsSupplier),binaryArtifactRepository);
     }
     
     @Test


### PR DESCRIPTION
Code refactoring: use common RestClient to make rest calls, so that the error handling and log lines are consistent.